### PR TITLE
Add modular Chrome extension for QA header analysis

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,8 @@
+import { crawlSite } from './modules/crawler.js';
+
+chrome.action.onClicked.addListener(async (tab) => {
+  if (!tab.url) return;
+  const data = await crawlSite(tab.url);
+  await chrome.storage.local.set({ report: data });
+  chrome.tabs.create({ url: chrome.runtime.getURL('report.html') });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "QA Explorer",
+  "version": "0.1.0",
+  "description": "Modular extension for website QA. Crawls site headers.",
+  "permissions": ["activeTab", "storage", "scripting"],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Run QA Explorer"
+  },
+  "options_ui": {
+    "page": "report.html",
+    "open_in_tab": true
+  }
+}

--- a/modules/crawler.js
+++ b/modules/crawler.js
@@ -1,0 +1,40 @@
+export async function crawlSite(startUrl) {
+  const origin = new URL(startUrl).origin;
+  const toVisit = [startUrl];
+  const visited = new Set();
+  const results = [];
+
+  while (toVisit.length) {
+    const url = toVisit.shift();
+    if (visited.has(url)) continue;
+    visited.add(url);
+
+    try {
+      const response = await fetch(url);
+      const text = await response.text();
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(text, 'text/html');
+
+      const headers = [];
+      for (let i = 1; i <= 6; i++) {
+        doc.querySelectorAll(`h${i}`).forEach(h => {
+          headers.push({ level: `h${i}`, text: h.textContent.trim() });
+        });
+      }
+      results.push({ url, headers });
+
+      doc.querySelectorAll('a[href]').forEach(a => {
+        const href = a.getAttribute('href');
+        if (!href) return;
+        const nextUrl = new URL(href, url);
+        if (nextUrl.origin === origin && !visited.has(nextUrl.href)) {
+          toVisit.push(nextUrl.href);
+        }
+      });
+    } catch (e) {
+      console.error('Failed to process', url, e);
+    }
+  }
+
+  return results;
+}

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,8 @@
-This is for localsearch
+# LSTool QA Explorer
+
+This repository contains a modular Chrome extension for website QA. The initial module crawls all internal pages of the current site, collects heading structure (H1-H6), and presents the results on a local report page. The report colour-codes each heading level and provides controls to adjust the colours in the preview.
+
+## Usage
+1. Load the extension in Chrome's developer mode.
+2. Navigate to a site and click the extension action to start crawling.
+3. After crawling, a report page opens showing all headings for each internal page.

--- a/report.css
+++ b/report.css
@@ -1,0 +1,26 @@
+:root {
+  --h1-color: #d32f2f;
+  --h2-color: #1976d2;
+  --h3-color: #388e3c;
+  --h4-color: #fbc02d;
+  --h5-color: #7b1fa2;
+  --h6-color: #455a64;
+  font-family: Arial, sans-serif;
+}
+
+#controls {
+  margin-bottom: 1em;
+}
+
+.header.h1 { color: var(--h1-color); }
+.header.h2 { color: var(--h2-color); }
+.header.h3 { color: var(--h3-color); }
+.header.h4 { color: var(--h4-color); }
+.header.h5 { color: var(--h5-color); }
+.header.h6 { color: var(--h6-color); }
+
+.page {
+  border-top: 1px solid #ccc;
+  padding-top: 0.5em;
+  margin-top: 0.5em;
+}

--- a/report.html
+++ b/report.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>QA Explorer Report</title>
+  <link rel="stylesheet" href="report.css">
+</head>
+<body>
+  <h1>Site Header Report</h1>
+  <div id="controls"></div>
+  <div id="pages"></div>
+  <script src="report.js" type="module"></script>
+</body>
+</html>

--- a/report.js
+++ b/report.js
@@ -1,0 +1,39 @@
+function rgbToHex(rgb) {
+  const result = rgb.match(/\d+/g).map(Number);
+  return '#' + result.map(x => x.toString(16).padStart(2, '0')).join('');
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const { report = [] } = await chrome.storage.local.get('report');
+  const pages = document.getElementById('pages');
+  report.forEach(page => {
+    const pageDiv = document.createElement('div');
+    pageDiv.className = 'page';
+    const title = document.createElement('h2');
+    title.textContent = page.url;
+    pageDiv.appendChild(title);
+    page.headers.forEach(h => {
+      const div = document.createElement('div');
+      div.className = `header ${h.level}`;
+      div.textContent = `${h.level.toUpperCase()}: ${h.text}`;
+      pageDiv.appendChild(div);
+    });
+    pages.appendChild(pageDiv);
+  });
+
+  const controls = document.getElementById('controls');
+  ['h1','h2','h3','h4','h5','h6'].forEach(level => {
+    const label = document.createElement('label');
+    label.textContent = `${level.toUpperCase()} color: `;
+    const input = document.createElement('input');
+    input.type = 'color';
+    const color = getComputedStyle(document.documentElement)
+      .getPropertyValue(`--${level}-color`).trim();
+    input.value = color.startsWith('#') ? color : rgbToHex(color);
+    input.addEventListener('input', () => {
+      document.documentElement.style.setProperty(`--${level}-color`, input.value);
+    });
+    label.appendChild(input);
+    controls.appendChild(label);
+  });
+});


### PR DESCRIPTION
## Summary
- add Chrome extension manifest and background service worker
- implement crawler module to fetch internal pages and extract H1-H6 headers
- provide local report page with color-coded headers and adjustable colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68901b40a58883258787f7cbee01bf16