### PR TITLE
Add popup UI with progress logs for crawler

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,8 +1,24 @@
 import { crawlSite } from './modules/crawler.js';
 
-chrome.action.onClicked.addListener(async (tab) => {
-  if (!tab.url) return;
-  const data = await crawlSite(tab.url);
-  await chrome.storage.local.set({ report: data });
-  chrome.tabs.create({ url: chrome.runtime.getURL('report.html') });
+chrome.runtime.onMessage.addListener(async (request) => {
+  if (request.type === 'start-crawl') {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab || !tab.url) {
+      chrome.runtime.sendMessage({ type: 'error', message: 'No active tab to crawl.' });
+      return;
+    }
+    chrome.runtime.sendMessage({ type: 'log', message: `Starting crawl at ${tab.url}` });
+    try {
+      const data = await crawlSite(
+        tab.url,
+        msg => chrome.runtime.sendMessage({ type: 'log', message: msg }),
+        msg => chrome.runtime.sendMessage({ type: 'error', message: msg })
+      );
+      await chrome.storage.local.set({ report: data });
+      chrome.runtime.sendMessage({ type: 'done' });
+      chrome.tabs.create({ url: chrome.runtime.getURL('report.html') });
+    } catch (e) {
+      chrome.runtime.sendMessage({ type: 'error', message: e.message });
+    }
+  }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -3,14 +3,22 @@
   "name": "QA Explorer",
   "version": "0.1.0",
   "description": "Modular extension for website QA. Crawls site headers.",
-  "permissions": ["activeTab", "storage", "scripting"],
-  "host_permissions": ["<all_urls>"],
+  "permissions": [
+    "activeTab",
+    "storage",
+    "scripting",
+    "tabs"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "background": {
     "service_worker": "background.js",
     "type": "module"
   },
   "action": {
-    "default_title": "Run QA Explorer"
+    "default_title": "Run QA Explorer",
+    "default_popup": "popup.html"
   },
   "options_ui": {
     "page": "report.html",

--- a/modules/crawler.js
+++ b/modules/crawler.js
@@ -1,4 +1,4 @@
-export async function crawlSite(startUrl) {
+export async function crawlSite(startUrl, onProgress = () => {}, onError = () => {}) {
   const origin = new URL(startUrl).origin;
   const toVisit = [startUrl];
   const visited = new Set();
@@ -8,6 +8,7 @@ export async function crawlSite(startUrl) {
     const url = toVisit.shift();
     if (visited.has(url)) continue;
     visited.add(url);
+    onProgress(`Visiting ${url}`);
 
     try {
       const response = await fetch(url);
@@ -32,7 +33,7 @@ export async function crawlSite(startUrl) {
         }
       });
     } catch (e) {
-      console.error('Failed to process', url, e);
+      onError(`Failed to process ${url}: ${e.message}`);
     }
   }
 

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>QA Explorer</title>
+  <style>
+    body { min-width: 200px; font-family: Arial, sans-serif; }
+    #log { max-height: 200px; overflow-y: auto; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <button id="start">Start Crawl</button>
+  <pre id="log"></pre>
+  <script type="module" src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,17 @@
+const startBtn = document.getElementById('start');
+const logEl = document.getElementById('log');
+
+startBtn.addEventListener('click', () => {
+  logEl.textContent = '';
+  chrome.runtime.sendMessage({ type: 'start-crawl' });
+});
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'log') {
+    logEl.textContent += msg.message + '\n';
+  } else if (msg.type === 'error') {
+    logEl.textContent += 'Error: ' + msg.message + '\n';
+  } else if (msg.type === 'done') {
+    logEl.textContent += 'Crawl complete.\n';
+  }
+});


### PR DESCRIPTION
## Summary
- Add popup menu to start crawling, display progress and errors
- Update background worker and crawler to send progress updates and handle errors
- Grant tabs permission and attach popup to extension action

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68901d72eb348325a3fc80495de22f5a