### PR TITLE
Handle missing message receivers

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,24 +1,32 @@
 import { crawlSite } from './modules/crawler.js';
 
+const safeSendMessage = (msg) => {
+  try {
+    chrome.runtime.sendMessage(msg).catch(() => {});
+  } catch (e) {
+    // ignore
+  }
+};
+
 chrome.runtime.onMessage.addListener(async (request) => {
   if (request.type === 'start-crawl') {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     if (!tab || !tab.url) {
-      chrome.runtime.sendMessage({ type: 'error', message: 'No active tab to crawl.' });
+      safeSendMessage({ type: 'error', message: 'No active tab to crawl.' });
       return;
     }
-    chrome.runtime.sendMessage({ type: 'log', message: `Starting crawl at ${tab.url}` });
+    safeSendMessage({ type: 'log', message: `Starting crawl at ${tab.url}` });
     try {
       const data = await crawlSite(
         tab.url,
-        msg => chrome.runtime.sendMessage({ type: 'log', message: msg }),
-        msg => chrome.runtime.sendMessage({ type: 'error', message: msg })
+        msg => safeSendMessage({ type: 'log', message: msg }),
+        msg => safeSendMessage({ type: 'error', message: msg })
       );
       await chrome.storage.local.set({ report: data });
-      chrome.runtime.sendMessage({ type: 'done' });
+      safeSendMessage({ type: 'done' });
       chrome.tabs.create({ url: chrome.runtime.getURL('report.html') });
     } catch (e) {
-      chrome.runtime.sendMessage({ type: 'error', message: e.message });
+      safeSendMessage({ type: 'error', message: e.message });
     }
   }
 });


### PR DESCRIPTION
## Summary
- prevent background from throwing when sending runtime messages without listeners

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68901f72a19083258da473c45d28b8bc