### PR TITLE
Implement recursive HTML crawler

### DIFF
--- a/background.js
+++ b/background.js
@@ -17,12 +17,12 @@ chrome.runtime.onMessage.addListener(async (request) => {
     }
     safeSendMessage({ type: 'log', message: `Starting crawl at ${tab.url}` });
     try {
-      const data = await crawlSite(
+      const { pages, collatedHtml } = await crawlSite(
         tab.url,
         msg => safeSendMessage({ type: 'log', message: msg }),
         msg => safeSendMessage({ type: 'error', message: msg })
       );
-      await chrome.storage.local.set({ report: data });
+      await chrome.storage.local.set({ report: pages, collated: collatedHtml });
       safeSendMessage({ type: 'done' });
       chrome.tabs.create({ url: chrome.runtime.getURL('report.html') });
     } catch (e) {

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,9 @@
 # LSTool QA Explorer
 
-This repository contains a modular Chrome extension for website QA. The initial module crawls all internal pages of the current site, collects heading structure (H1-H6), and presents the results on a local report page. The report colour-codes each heading level and provides controls to adjust the colours in the preview.
+This repository contains a modular Chrome extension for website QA. It crawls all internal pages of the current site, collects HTML for each page while staying on the origin, and collates the results into a local report.
 
 ## Usage
 1. Load the extension in Chrome's developer mode.
 2. Navigate to a site and click the extension action to start crawling.
-3. After crawling, a report page opens showing all headings for each internal page.
+3. After crawling, a report page opens showing a summary of header counts for each internal page.
+

--- a/report.css
+++ b/report.css
@@ -8,8 +8,24 @@
   font-family: Arial, sans-serif;
 }
 
+body {
+  margin: 1em;
+}
+
 #controls {
   margin-bottom: 1em;
+}
+
+#summary {
+  border-collapse: collapse;
+  margin-bottom: 1em;
+  width: 100%;
+}
+
+#summary th, #summary td {
+  border: 1px solid #ccc;
+  padding: 0.25em 0.5em;
+  text-align: left;
 }
 
 .header.h1 { color: var(--h1-color); }

--- a/report.html
+++ b/report.html
@@ -8,6 +8,7 @@
 <body>
   <h1>Site Header Report</h1>
   <div id="controls"></div>
+  <table id="summary"></table>
   <div id="pages"></div>
   <script src="report.js" type="module"></script>
 </body>

--- a/report.js
+++ b/report.js
@@ -5,24 +5,60 @@ function rgbToHex(rgb) {
 
 document.addEventListener('DOMContentLoaded', async () => {
   const { report = [] } = await chrome.storage.local.get('report');
-  const pages = document.getElementById('pages');
+  const summaryTable = document.getElementById('summary');
+  const pagesContainer = document.getElementById('pages');
+  const levels = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+
+  // Build summary header row
+  const headerRow = document.createElement('tr');
+  const thPage = document.createElement('th');
+  thPage.textContent = 'Page';
+  headerRow.appendChild(thPage);
+  levels.forEach(level => {
+    const th = document.createElement('th');
+    th.textContent = level.toUpperCase();
+    headerRow.appendChild(th);
+  });
+  summaryTable.appendChild(headerRow);
+
   report.forEach(page => {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(page.html, 'text/html');
+    const headers = Array.from(doc.querySelectorAll(levels.join(','))).map(h => ({
+      level: h.tagName.toLowerCase(),
+      text: h.textContent.trim()
+    }));
+
+    // Summary row
+    const row = document.createElement('tr');
+    const urlCell = document.createElement('td');
+    urlCell.textContent = page.url;
+    row.appendChild(urlCell);
+    levels.forEach(level => {
+      const cell = document.createElement('td');
+      cell.textContent = headers.filter(h => h.level === level).length;
+      row.appendChild(cell);
+    });
+    summaryTable.appendChild(row);
+
+    // Detailed headers per page
     const pageDiv = document.createElement('div');
     pageDiv.className = 'page';
     const title = document.createElement('h2');
     title.textContent = page.url;
     pageDiv.appendChild(title);
-    page.headers.forEach(h => {
+    headers.forEach(h => {
       const div = document.createElement('div');
       div.className = `header ${h.level}`;
       div.textContent = `${h.level.toUpperCase()}: ${h.text}`;
       pageDiv.appendChild(div);
     });
-    pages.appendChild(pageDiv);
+    pagesContainer.appendChild(pageDiv);
   });
 
+  // Color controls
   const controls = document.getElementById('controls');
-  ['h1','h2','h3','h4','h5','h6'].forEach(level => {
+  levels.forEach(level => {
     const label = document.createElement('label');
     label.textContent = `${level.toUpperCase()} color: `;
     const input = document.createElement('input');


### PR DESCRIPTION
## Summary
- Add summary table counting header levels per internal page
- Restore detailed header list with color customization for each page
- Document header summary output in README

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68902257954c83259c0a9548291f7aa1