### PR TITLE
fix: call module run and improve crawler error handling

### DIFF
--- a/background.js
+++ b/background.js
@@ -28,7 +28,7 @@ chrome.runtime.onMessage.addListener(async (request) => {
 
     safeSendMessage({ type: 'log', message: `Running ${mod.name} at ${tab.url}` });
     try {
-
+      await mod.run(
         tab.url,
         {
           log: (msg) => safeSendMessage({ type: 'log', message: msg }),

--- a/modules/crawler.js
+++ b/modules/crawler.js
@@ -27,6 +27,11 @@ export async function run(startUrl, { log = () => {}, error = () => {} } = {}) {
 
     try {
       const response = await fetch(url);
+      if (!response.ok) {
+        error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+        continue;
+      }
+
       const text = await response.text();
       pages.push({ url, html: text });
 
@@ -36,7 +41,12 @@ export async function run(startUrl, { log = () => {}, error = () => {} } = {}) {
       doc.querySelectorAll('a[href]').forEach(a => {
         const href = a.getAttribute('href');
         if (!href) return;
-        const nextUrl = new URL(href, url);
+        let nextUrl;
+        try {
+          nextUrl = new URL(href, url);
+        } catch {
+          return;
+        }
         if (
           nextUrl.origin === origin &&
           !visited.has(nextUrl.href) &&


### PR DESCRIPTION
## Summary
- correctly invoke module run in background worker and forward logs safely
- harden crawler module against fetch failures and malformed links

## Testing
- `npm test >/tmp/test.log && cat /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68902bf08724832586e397e78e822d5f