### PR TITLE
feat: summarize headers in crawl report

### DIFF
--- a/modules/crawler.js
+++ b/modules/crawler.js
@@ -41,7 +41,12 @@ export async function run(startUrl, { log = () => {}, error = () => {} } = {}) {
       const body = doc.body.cloneNode(true);
       body.querySelectorAll('script, style').forEach(el => el.remove());
 
-      pages.push({ url, html: body.innerHTML });
+      const headers = [];
+      body.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
+        headers.push({ level: h.tagName.toLowerCase(), text: h.textContent.trim() });
+      });
+
+      pages.push({ url, html: body.innerHTML, headers });
 
       doc.querySelectorAll('a[href]').forEach(a => {
         const href = a.getAttribute('href');
@@ -72,9 +77,11 @@ export async function run(startUrl, { log = () => {}, error = () => {} } = {}) {
     )
     .join('\n');
 
-  // Store the collated HTML and open the report page for viewing.
-  await chrome.storage.local.set({ collatedHtml });
+  const headerSummary = pages.map((p) => ({ url: p.url, headers: p.headers }));
+
+  // Store the collated HTML and header summary then open the report page for viewing.
+  await chrome.storage.local.set({ collatedHtml, headerSummary });
   await chrome.runtime.openOptionsPage();
 
-  return { pages, collatedHtml };
+  return { pages, collatedHtml, headerSummary };
 }

--- a/report.css
+++ b/report.css
@@ -3,6 +3,19 @@ body {
   margin: 1em;
 }
 
+#summary {
+  margin-bottom: 2em;
+}
+
+#summary section {
+  margin-bottom: 1em;
+}
+
+#summary h2 {
+  font-size: 1.1em;
+  margin: 0 0 0.5em;
+}
+
 .page {
   margin-bottom: 2em;
   border-bottom: 1px solid #ccc;

--- a/report.html
+++ b/report.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="report.css">
 </head>
 <body>
+  <div id="summary"></div>
   <div id="content"></div>
   <script src="report.js" type="module"></script>
 </body>

--- a/report.js
+++ b/report.js
@@ -1,6 +1,31 @@
 document.addEventListener('DOMContentLoaded', async () => {
-  const { collatedHtml } = await chrome.storage.local.get('collatedHtml');
+  const { collatedHtml, headerSummary } = await chrome.storage.local.get([
+    'collatedHtml',
+    'headerSummary',
+  ]);
+  const summaryEl = document.getElementById('summary');
   const container = document.getElementById('content');
+
+  if (headerSummary && headerSummary.length) {
+    headerSummary.forEach((page) => {
+      const section = document.createElement('section');
+      const heading = document.createElement('h2');
+      heading.textContent = page.url;
+      section.appendChild(heading);
+
+      const list = document.createElement('ul');
+      page.headers.forEach((h) => {
+        const li = document.createElement('li');
+        li.textContent = `${h.level.toUpperCase()}: ${h.text}`;
+        list.appendChild(li);
+      });
+      section.appendChild(list);
+      summaryEl.appendChild(section);
+    });
+  } else {
+    summaryEl.textContent = 'No header summary available.';
+  }
+
   if (collatedHtml) {
     container.innerHTML = collatedHtml;
   } else {


### PR DESCRIPTION
## Summary
- crawl site recursively and capture heading tags from each page
- show header summary and raw HTML on report page

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68902fb0b7ac8325b9e485aa4a00e4fc